### PR TITLE
미디어 컴포넌트 마이그레이션 및 리팩토링 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // AWS Java S3 SDK - AWS S3 스토리지와 통신을 수행할 때 사용하는 디펜던시.
+    implementation("software.amazon.awssdk:s3:2.28.16")
 }
 
 kotlin {

--- a/src/main/kotlin/org/tenten/bittakotlin/demo/User.java
+++ b/src/main/kotlin/org/tenten/bittakotlin/demo/User.java
@@ -1,0 +1,25 @@
+package org.tenten.bittakotlin.demo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String email;
+    private String phone;
+
+    public User() {}
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/demo/UserController.java
+++ b/src/main/kotlin/org/tenten/bittakotlin/demo/UserController.java
@@ -1,0 +1,24 @@
+package org.tenten.bittakotlin.demo;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @PostMapping
+    public User addUser(@RequestBody User user) {
+        return userRepository.save(user);
+    }
+
+    @GetMapping
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/demo/UserRepository.java
+++ b/src/main/kotlin/org/tenten/bittakotlin/demo/UserRepository.java
@@ -1,0 +1,6 @@
+package org.tenten.bittakotlin.demo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {}
+

--- a/src/main/kotlin/org/tenten/bittakotlin/global/config/S3Config.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/global/config/S3Config.kt
@@ -1,0 +1,41 @@
+package org.tenten.bittakotlin.global.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+
+@Configuration
+class S3Config(
+    @Value("\${s3.access.id}")
+    private val accessId: String,
+
+    @Value("\${s3.secret.key}")
+    private val secretKey: String
+) {
+    @Bean
+    fun s3Client() : S3Client {
+        val basicCredentials: AwsBasicCredentials
+            = AwsBasicCredentials.create(accessId, secretKey)
+
+        return S3Client.builder()
+            .region(Region.AP_NORTHEAST_2)
+            .credentialsProvider(StaticCredentialsProvider.create(basicCredentials))
+            .build()
+    }
+
+    @Bean
+    fun s3Presigner() : S3Presigner {
+        val basicCredentials: AwsBasicCredentials
+            = AwsBasicCredentials.create(accessId, secretKey)
+
+        return S3Presigner.builder()
+            .region(Region.AP_NORTHEAST_2)
+            .credentialsProvider(StaticCredentialsProvider.create(basicCredentials))
+            .build()
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/constant/MediaError.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/constant/MediaError.kt
@@ -1,0 +1,10 @@
+package org.tenten.bittakotlin.media.constant
+
+import org.springframework.http.HttpStatus
+
+enum class MediaError(val code: Int, val message: String) {
+    WRONG_FILE_SIZE(HttpStatus.BAD_REQUEST.value(), "이미지 파일은 10MB, 비디오 파일은 30MB를 초과할 수 없습니다."),
+    WRONG_MIME_TYPE(HttpStatus.BAD_REQUEST.value(), "올바르지 않은 파일 유형입니다."),
+    CANNOT_FOUND(HttpStatus.NOT_FOUND.value(), "DB에 파일이 존재하지 않습니다."),
+    S3_CANNOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "S3 서버에 파일이 존재하지 않습니다.")
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/constant/MediaType.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/constant/MediaType.kt
@@ -1,0 +1,5 @@
+package org.tenten.bittakotlin.media.constant
+
+enum class MediaType {
+    IMAGE, VIDEO
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/controller/MediaController.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/controller/MediaController.kt
@@ -1,0 +1,31 @@
+package org.tenten.bittakotlin.media.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.tenten.bittakotlin.media.dto.MediaRequestDto
+import org.tenten.bittakotlin.media.service.MediaService
+
+@RestController
+@RequestMapping("/api/v1/media")
+class MediaController(
+    private val mediaService: MediaService
+) {
+    @GetMapping("/upload")
+    fun upload(@RequestBody requestDto: MediaRequestDto.Upload): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.ok(mapOf(
+            "message" to "파일 업로드 링크를 성공적으로 생성했습니다.",
+            "url" to mediaService.upload(requestDto)
+        ))
+    }
+
+    @GetMapping("/read")
+    fun read(@RequestBody requestDto: MediaRequestDto.Read): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.ok(mapOf(
+            "message" to "파일 조회 링크를 성공적으로 생성했습니다.",
+            "url" to mediaService.read(requestDto)
+        ))
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/controller/MediaControllerAdvice.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/controller/MediaControllerAdvice.kt
@@ -1,0 +1,14 @@
+package org.tenten.bittakotlin.media.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.tenten.bittakotlin.media.exception.MediaException
+
+@RestControllerAdvice
+class MediaControllerAdvice {
+    @ExceptionHandler(MediaException::class)
+    fun handleMediaException(e: MediaException): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.status(e.code).body(mapOf("error" to e.message))
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/dto/MediaRequestDto.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/dto/MediaRequestDto.kt
@@ -1,0 +1,34 @@
+package org.tenten.bittakotlin.media.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+class MediaRequestDto {
+    data class Read (
+        @field:NotBlank(message = "파일명이 비어있습니다.")
+        val filename: String
+    )
+
+    data class Upload (
+        @field:NotBlank(message = "파일명이 비어있습니다.")
+        val filename: String,
+
+        @field:Min(value = 0, message = "비어있는 파일은 업로드할 수 없습니다.")
+        @field:NotBlank(message = "파일 크기가 비어있습니다.")
+        val filesize: Int,
+
+        @field:Pattern(regexp = "(image/(jpeg|png|gif|bmp|webp|svg\\+xml))|(video/(mp4|webm|ogg|x-msvideo|x-matroska))"
+            , message = "지원하지 않는 파일 형식입니다.")
+        @field:NotBlank(message = "파일 형식이 비어있습니다.")
+        val mimetype: String
+    )
+
+    data class Delete (
+        @field:NotBlank(message = "회원명이 비어있습니다.")
+        val username: String,
+
+        @field:NotBlank(message = "파일명이 비어있습니다.")
+        val filename: String
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/dto/MediaResponseDto.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/dto/MediaResponseDto.kt
@@ -1,0 +1,15 @@
+package org.tenten.bittakotlin.media.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class MediaResponseDto {
+    data class Read (
+        @field:NotBlank(message = "조회 링크가 비어있습니다.")
+        val link: String
+    )
+
+    data class Upload (
+        @field:NotBlank(message = "업로드 링크가 비어있습니다.")
+        val link: String
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/entity/Media.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/entity/Media.kt
@@ -1,0 +1,37 @@
+package org.tenten.bittakotlin.media.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.tenten.bittakotlin.media.constant.MediaType
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+data class Media (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val filename: String,
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    val filesize: Int,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val filetype: MediaType,
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    val savedAt: LocalDateTime? = null,
+
+    /*
+        회원과 1:N으로 연결할 예정입니다.
+        임시로 문자열로 구성해놓았습니다.
+     */
+    val member: String? = null
+)

--- a/src/main/kotlin/org/tenten/bittakotlin/media/exception/MediaException.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/exception/MediaException.kt
@@ -1,0 +1,14 @@
+package org.tenten.bittakotlin.media.exception
+
+import org.tenten.bittakotlin.media.constant.MediaError
+
+class MediaException(
+    val code: Int,
+
+    override val message: String
+) : RuntimeException(message) {
+    constructor(mediaError: MediaError) : this(
+        code = mediaError.code,
+        message = mediaError.message
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/repository/MediaRepository.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/repository/MediaRepository.kt
@@ -1,0 +1,17 @@
+package org.tenten.bittakotlin.media.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import org.tenten.bittakotlin.media.entity.Media
+import java.util.Optional
+
+@Repository
+interface MediaRepository : JpaRepository<Media, Long> {
+    @Query("SELECT m FROM Media m WHERE m.filename = :filename")
+    fun findByFilename(@Param("filename") filename: String): Optional<Media>
+
+    @Query("SELECT m FROM Media m WHERE m.filename = :filename AND m.member = :member")
+    fun findByFilenameAndUsername(@Param("filename") filename: String, @Param("member") member: String): Optional<Media>
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/service/MediaService.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/service/MediaService.kt
@@ -1,0 +1,11 @@
+package org.tenten.bittakotlin.media.service
+
+import org.tenten.bittakotlin.media.dto.MediaRequestDto
+
+interface MediaService {
+    fun read(requestDto: MediaRequestDto.Read): String
+
+    fun upload(requestDto: MediaRequestDto.Upload): String
+
+    fun delete(requestDto: MediaRequestDto.Delete): Unit
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/service/MediaServiceImpl.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/service/MediaServiceImpl.kt
@@ -1,0 +1,97 @@
+package org.tenten.bittakotlin.media.service
+
+import jakarta.transaction.Transactional
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.tenten.bittakotlin.media.constant.MediaError
+import org.tenten.bittakotlin.media.constant.MediaType
+import org.tenten.bittakotlin.media.dto.MediaRequestDto
+import org.tenten.bittakotlin.media.entity.Media
+import org.tenten.bittakotlin.media.exception.MediaException
+import org.tenten.bittakotlin.media.repository.MediaRepository
+import java.util.*
+
+@Service
+class MediaServiceImpl(
+    private val mediaRepository: MediaRepository,
+
+    private val s3Service: S3Service,
+
+    @Value("\${file.max.size.image}")
+    private val imageMaxSize: Int,
+
+    @Value("\${file.max.size.video}")
+    private val videoMaxSize: Int
+) : MediaService {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(MediaServiceImpl::class.java)
+    }
+
+    override fun read(requestDto: MediaRequestDto.Read): String {
+        val result: Media = mediaRepository.findByFilename(requestDto.filename)
+            .orElseThrow { MediaException(MediaError.CANNOT_FOUND) }
+
+        return s3Service.getReadUrl(result.filename)
+    }
+
+    override fun upload(requestDto: MediaRequestDto.Upload): String {
+        val filename: String = UUID.randomUUID().toString()
+        val filetype: MediaType = checkMimetype(requestDto.mimetype)
+        val filesize: Int = checkFileSize(requestDto.filesize, filetype)
+
+        mediaRepository.save(Media(
+            filename = filename,
+            filetype = filetype,
+            filesize = filesize
+        ))
+
+        return s3Service.getUploadUrl(filename, requestDto.mimetype)
+    }
+
+    @Transactional
+    override fun delete(requestDto: MediaRequestDto.Delete) {
+        val filename: String = requestDto.filename
+        val username: String = requestDto.username
+        val result: Media = mediaRepository.findByFilenameAndUsername(filename, username)
+            .orElseThrow {
+                logger.warn("The file data does not exist in DB: filename=$filename, username=$username")
+
+                MediaException(MediaError.CANNOT_FOUND)
+            }
+
+        s3Service.delete(result.filename)
+        mediaRepository.deleteById(result.id!!)
+    }
+
+    private fun checkMimetype(mimetype: String): MediaType {
+        if (mimetype.matches(Regex("image/(jpeg|png|gif|bmp|webp|svg\\+xml)"))) {
+            logger.info("")
+            return MediaType.IMAGE
+        }
+
+        if (mimetype.matches(Regex("video/(mp4|webm|ogg|x-msvideo|x-matroska)"))) {
+            logger.info("")
+            return MediaType.VIDEO
+        }
+
+        logger.warn("The file type is not valid: filetype=$mimetype")
+        throw MediaException(MediaError.WRONG_MIME_TYPE)
+    }
+
+    private fun checkFileSize(filesize: Int, type: MediaType): Int {
+        val maxSize: Int = if (type == MediaType.IMAGE) {
+            imageMaxSize
+        } else {
+            videoMaxSize
+        }
+
+        if (filesize > maxSize) {
+            logger.warn("The file size exceeds the allowed limit: filesize=$filesize")
+            throw MediaException(MediaError.WRONG_FILE_SIZE)
+        }
+
+        return filesize
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/service/S3Service.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/service/S3Service.kt
@@ -1,0 +1,9 @@
+package org.tenten.bittakotlin.media.service
+
+interface S3Service {
+    fun getReadUrl(name: String): String
+
+    fun getUploadUrl(name: String, contentType: String): String
+
+    fun delete(filename: String): Unit
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/media/service/S3ServiceImpl.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/media/service/S3ServiceImpl.kt
@@ -1,0 +1,83 @@
+package org.tenten.bittakotlin.media.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.tenten.bittakotlin.media.constant.MediaError
+import org.tenten.bittakotlin.media.exception.MediaException
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest
+import java.time.Duration
+
+@Service
+class S3ServiceImpl(
+    @Value("\${s3.bucket.name}")
+    private val s3Bucket: String,
+
+    private val s3Client: S3Client,
+
+    private val s3Presigner: S3Presigner
+) : S3Service {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(S3ServiceImpl::class.java)
+    }
+
+    override fun getReadUrl(name: String): String {
+        existsInBucket(name)
+
+        val presignedGetRequest: PresignedGetObjectRequest = s3Presigner.presignGetObject { request -> request
+            .signatureDuration(Duration.ofMinutes(10))
+            .getObjectRequest {getRequest -> getRequest
+                .bucket(s3Bucket)
+                .key(name)
+                .build()
+            }
+        }
+
+        return presignedGetRequest.url().toString()
+    }
+
+    override fun getUploadUrl(name: String, contentType: String): String {
+        val presignedPutRequest: PresignedPutObjectRequest = s3Presigner.presignPutObject { request -> request
+            .signatureDuration(Duration.ofMinutes(3))
+            .putObjectRequest { putRequest -> putRequest
+                .bucket(s3Bucket)
+                .key(name)
+                .contentType(contentType)
+                .build()
+            }
+        }
+
+        return presignedPutRequest.url().toString()
+    }
+
+    override fun delete(name: String): Unit {
+        existsInBucket(name)
+
+        s3Client.deleteObject { delRequest -> delRequest
+            .bucket(s3Bucket)
+            .key(name)
+            .build()
+        }
+    }
+
+    private fun existsInBucket(name: String): Unit {
+        try {
+            val headRequest: HeadObjectRequest = HeadObjectRequest.builder()
+                .bucket(s3Bucket)
+                .key(name)
+                .build()
+
+            s3Client.headObject(headRequest)
+        } catch (e: NoSuchKeyException) {
+            logger.warn("Cannot found any file in bucket: $name")
+
+            throw MediaException(MediaError.S3_CANNOT_FOUND)
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,6 @@
-# Application name
+# application name
 spring.application.name=bitta-kotlin
+
+# file size limit
+file.max.size.image=10485760
+file.max.size.video=31457280


### PR DESCRIPTION
## #️⃣연관된 이슈
See: prgrms-be-devcourse/NBB1_2_3_Team10#1


## ☑️ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정


## 📝 작업 내용
S3와 미디어 관련 컴포넌트를 자바에서 코틀린으로 마이그레이션하고,
잘못된 기능들을 수정하고 리팩토링을 수행했습니다.
대략적인 사항은 아래와 같습니다.

- 다른 테이블의 종속성을 제거하고, 중간 테이블로 다룰 예정입니다.
- 서버가 파일을 직접 업로드 하는 방식에서 서명 링크를 반환하는 방식으로 변경했습니다.
- 예외 클래스가 관련 Enum을 매개변수로 직접 생성되는 방식으로 변경했습니다.

## ✅ 피드백 반영사항
피드백 사항은 따로 없습니다.

## 💬 리뷰 요구사항
미디어에 액세스가 필요한 도메인은 중간 테이블을 반드시 두어야만 할 것입니다.

