### PR TITLE
채팅 컴포넌트 마이그레이션 및 리팩토링 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
     // H2 Database Engine - 테스트에서 사용하는 인메모리 데이터베이스 H2
     testImplementation("com.h2database:h2:2.3.232")
 
+    // Spring Boot Starter Websocket - 웹소켓 통신을 수행할 때 사용하는 디펜던시
+    implementation("org.springframework.boot:spring-boot-starter-websocket:3.3.4")
+
     //JWT 의존성
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.3")

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/constant/ChatError.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/constant/ChatError.kt
@@ -1,0 +1,11 @@
+package org.tenten.bittakotlin.chat.constant
+
+import org.springframework.http.HttpStatus
+
+enum class ChatError(val code: Int, val message: String) {
+    CANNOT_FOUND_MEMBER(HttpStatus.NOT_FOUND.value(), "채팅할 대상 회원을 찾을 수 없습니다."),
+    CANNOT_FOUND_CHAT(HttpStatus.NOT_FOUND.value(), "채팅이 존재하지 않거나, 삭제되었습니다."),
+    CANNOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND.value(), "아직 대화하지 않은 상대입니다."),
+    CANNOT_CHAT_CAUSE_BLOCKED(HttpStatus.FORBIDDEN.value(), "현재 대화할 수 없는 상대입니다."),
+    ALREADY_DELETED_CHAT(HttpStatus.BAD_REQUEST.value(), "이미 삭제된 메시지입니다.")
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/controller/ChatController.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/controller/ChatController.kt
@@ -1,0 +1,70 @@
+package org.tenten.bittakotlin.chat.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.tenten.bittakotlin.chat.dto.ChatRequestDto
+import org.tenten.bittakotlin.chat.dto.ChatResponseDto
+import org.tenten.bittakotlin.chat.dto.ChatRoomRequestDto
+import org.tenten.bittakotlin.chat.service.ChatRoomService
+import org.tenten.bittakotlin.chat.service.ChatService
+import org.tenten.bittakotlin.media.dto.MediaRequestDto
+import org.tenten.bittakotlin.media.service.MediaService
+
+@RestController
+@RequestMapping("/api/v1/chat")
+class ChatController(
+    private val simpMessagingTemplate: SimpMessagingTemplate,
+
+    private val chatService: ChatService,
+
+    private val chatRoomService: ChatRoomService
+) {
+    @MessageMapping("/send")
+    fun send(@RequestBody requestDto: ChatRequestDto.Send): Unit {
+        val responseDto: ChatResponseDto.Send = chatService.save(requestDto)
+
+        simpMessagingTemplate.convertAndSend("/room/${responseDto.chatRoomId}", responseDto)
+    }
+
+    @GetMapping("/room")
+    fun read(@RequestBody requestDto: ChatRequestDto.Read): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.ok(mapOf(
+            "message" to "파일 조회 링크를 성공적으로 생성했습니다.",
+            "result" to chatService.get(requestDto)
+        ))
+    }
+
+    @PostMapping("/room")
+    fun block(@RequestBody requestDto: ChatRoomRequestDto.Block): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.ok(mapOf(
+            "message" to if (chatRoomService.toggleBlocked(requestDto)) {
+                "해당 회원을 차단 해제했습니다."
+            } else {
+                "해당 회원을 차단 설정했습니다."
+            }
+        ))
+    }
+
+    @DeleteMapping("/message/{chatId}")
+    fun delete(@PathVariable chatId: Long): ResponseEntity<Map<String, Any>> {
+        val chatRoomId: Long = chatService.delete(chatId)!!
+
+        simpMessagingTemplate.convertAndSend("/room/$chatRoomId",
+            ChatResponseDto.Delete(
+                chatRoomId = chatRoomId,
+                chatId = chatId,
+                message = "삭제된 메시지 입니다."
+            )
+        )
+
+        return ResponseEntity.ok(mapOf("message" to "메시지를 성공적으로 삭제했습니다."))
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/controller/ChatControllerAdvice.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/controller/ChatControllerAdvice.kt
@@ -1,0 +1,14 @@
+package org.tenten.bittakotlin.chat.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.tenten.bittakotlin.media.exception.ChatException
+
+@RestControllerAdvice
+class ChatControllerAdvice {
+    @ExceptionHandler(ChatException::class)
+    fun handleMediaException(e: ChatException): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.status(e.code).body(mapOf("error" to e.message))
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/dto/ChatRequestDto.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/dto/ChatRequestDto.kt
@@ -1,0 +1,33 @@
+package org.tenten.bittakotlin.chat.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+class ChatRequestDto {
+    data class Read(
+        @field:NotBlank(message = "발신자 닉네임이 비어있습니다.")
+        val sender: String,
+
+        @field:NotBlank(message = "수신자 닉네임이 비어있습니다.")
+        val receiver: String,
+    )
+
+    data class Send(
+        @field:NotBlank(message = "발신자 닉네임이 비어있습니다.")
+        val sender: String,
+
+        @field:NotBlank(message = "수신자 닉네임이 비어있습니다.")
+        val receiver: String,
+
+        @field:NotBlank(message = "메시지가 비어있습니다.")
+        val message: String
+    )
+
+    data class Update(
+        @field:Min(value = 1, message = "인덱스는 0 또는 음수가 될 수 없습니다.")
+        val chatId: Long,
+
+        @field:NotBlank(message = "메시지가 비어있습니다.")
+        val message: String
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/dto/ChatResponseDto.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/dto/ChatResponseDto.kt
@@ -1,0 +1,56 @@
+package org.tenten.bittakotlin.chat.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDateTime
+
+class ChatResponseDto {
+    data class Read(
+        @field:Min(value = 1, message = "인덱스는 0 또는 음수가 될 수 없습니다.")
+        val chatId: Long,
+
+        @field:NotBlank(message = "발신자 닉네임이 비어있습니다.")
+        val sender: String,
+
+        @field:NotBlank(message = "메시지가 비어있습니다.")
+        val message: String,
+        
+        val deleted: Boolean,
+
+        val chatAt: LocalDateTime
+    )
+
+    data class Send(
+        @field:Min(value = 1, message = "인덱스는 0 또는 음수가 될 수 없습니다.")
+        val chatRoomId: Long,
+
+        val activated: Boolean,
+
+        @field:NotBlank(message = "비어있는 메시지를 전송할 수 없습니다.")
+        val detail: Detail
+    )
+
+    data class Delete(
+        @field:Min(value = 1, message = "인덱스는 0 또는 음수가 될 수 없습니다.")
+        val chatRoomId: Long,
+
+        @field:Min(value = 1, message = "인덱스는 0 또는 음수가 될 수 없습니다.")
+        val chatId: Long,
+
+        @field:NotBlank(message = "메시지가 비어있습니다.")
+        val message: String
+    )
+
+    data class Detail(
+        @field:Min(value = 1, message = "인덱스는 0 또는 음수가 될 수 없습니다.")
+        val chatId: Long,
+
+        @field:NotBlank(message = "발신자 닉네임이 비어있습니다.")
+        val sender: String,
+
+        @field:NotBlank(message = "메시지가 비어있습니다.")
+        val message: String,
+
+        val chatAt: LocalDateTime
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/dto/ChatRoomRequestDto.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/dto/ChatRoomRequestDto.kt
@@ -1,0 +1,21 @@
+package org.tenten.bittakotlin.chat.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class ChatRoomRequestDto {
+    data class Create(
+        @field:NotBlank(message = "회원 닉네임이 비어있습니다.")
+        val nickname1: String,
+
+        @field:NotBlank(message = "회원 닉네임이 비어있습니다.")
+        val nickname2: String
+    )
+
+    data class Block(
+        @field:NotBlank(message = "차단 요청 회원의 닉네임은 비워둘 수 없습니다.")
+        val requester: String,
+
+        @field:NotBlank(message = "차단 대상 회원의 닉네임은 비워둘 수 없습니다.")
+        val target: String
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/entity/Chat.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/entity/Chat.kt
@@ -1,0 +1,38 @@
+package org.tenten.bittakotlin.chat.entity
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.tenten.bittakotlin.profile.entity.Profile
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+data class Chat(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(length = 400, nullable = false)
+    var message: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    val profile: Profile,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "room_id")
+    val chatRoom: ChatRoom,
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
+    var deleted: Boolean = false,
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    val createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    val updatedAt: LocalDateTime?
+)

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/entity/ChatRoom.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/entity/ChatRoom.kt
@@ -1,0 +1,36 @@
+package org.tenten.bittakotlin.chat.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+data class ChatRoom(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 1", nullable = false)
+    var activated: Boolean = true,
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    val createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    val updatedAt: LocalDateTime?
+) {
+    constructor(): this(
+        createdAt = null,
+        updatedAt = null
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/entity/ChatRoomProfile.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/entity/ChatRoomProfile.kt
@@ -1,0 +1,26 @@
+package org.tenten.bittakotlin.chat.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import org.tenten.bittakotlin.chat.entity.key.ChatRoomProfileId
+import org.tenten.bittakotlin.profile.entity.Profile
+
+@Entity
+data class ChatRoomProfile(
+    @EmbeddedId
+    val id: ChatRoomProfileId? = null,
+
+    @ManyToOne
+    @MapsId("chatRoomId")
+    val chatRoom: ChatRoom,
+
+    @ManyToOne
+    @MapsId("profileId")
+    val profile: Profile,
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
+    var blocked: Boolean = false
+)

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/entity/key/ChatRoomProfileId.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/entity/key/ChatRoomProfileId.kt
@@ -1,0 +1,11 @@
+package org.tenten.bittakotlin.chat.entity.key
+
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+
+@Embeddable
+data class ChatRoomProfileId(
+    val chatRoomId: Long,
+
+    val profileId: Long
+) : Serializable

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/exception/ChatException.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/exception/ChatException.kt
@@ -1,0 +1,15 @@
+package org.tenten.bittakotlin.media.exception
+
+import org.tenten.bittakotlin.chat.constant.ChatError
+import org.tenten.bittakotlin.media.constant.MediaError
+
+class ChatException(
+    val code: Int,
+
+    override val message: String
+) : RuntimeException(message) {
+    constructor(chatError: ChatError) : this(
+        code = chatError.code,
+        message = chatError.message
+    )
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/repository/ChatRepository.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/repository/ChatRepository.kt
@@ -1,0 +1,13 @@
+package org.tenten.bittakotlin.chat.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import org.tenten.bittakotlin.chat.entity.Chat
+
+@Repository
+interface ChatRepository : JpaRepository<Chat, Long> {
+    @Query("SELECT c FROM Chat c WHERE c.chatRoom.id = :chatRoomId")
+    fun findAllByChatRoomId(@Param("chatRoomId") chatRoomId: Long): List<Chat>
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/repository/ChatRoomProfileRepository.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/repository/ChatRoomProfileRepository.kt
@@ -1,0 +1,23 @@
+package org.tenten.bittakotlin.chat.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import org.tenten.bittakotlin.chat.entity.ChatRoom
+import org.tenten.bittakotlin.chat.entity.ChatRoomProfile
+import org.tenten.bittakotlin.chat.entity.key.ChatRoomProfileId
+import java.util.Optional
+
+@Repository
+interface ChatRoomProfileRepository : JpaRepository<ChatRoomProfile, ChatRoomProfileId> {
+    @Query("SELECT crf.chatRoom " +
+            "FROM ChatRoomProfile crf " +
+            "WHERE crf.profile = :nickname1 OR crf.profile = :nickname2 " +
+            "GROUP BY crf.chatRoom " +
+            "HAVING COUNT(crf.chatRoom) = 2")
+    fun findChatRoomByNicknames(@Param("nickname1") nickname1: String, @Param("nickname2") nickname2: String): Optional<ChatRoom>
+
+    @Query("SELECT crf FROM ChatRoomProfile crf WHERE crf.chatRoom = :chatRoom AND crf.profile.nickname = :nickname")
+    fun findChatRoomByChatRoomAndNickname(@Param("chatRoom") chatRoom: ChatRoom, @Param("nickname") nickname: String): ChatRoomProfile
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/repository/ChatRoomRepository.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/repository/ChatRoomRepository.kt
@@ -1,0 +1,9 @@
+package org.tenten.bittakotlin.chat.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import org.tenten.bittakotlin.chat.entity.ChatRoom
+
+@Repository
+interface ChatRoomRepository : JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatRoomService.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatRoomService.kt
@@ -1,0 +1,12 @@
+package org.tenten.bittakotlin.chat.service
+
+import org.tenten.bittakotlin.chat.dto.ChatRoomRequestDto
+import org.tenten.bittakotlin.chat.entity.ChatRoom
+
+interface ChatRoomService {
+    fun getChatRoomByNicknames(nickname1: String, nickname2: String): ChatRoom
+
+    fun save(requestDto: ChatRoomRequestDto.Create): ChatRoom
+
+    fun toggleBlocked(requestDto: ChatRoomRequestDto.Block): Boolean
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatRoomServiceImpl.kt
@@ -1,0 +1,83 @@
+package org.tenten.bittakotlin.chat.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.tenten.bittakotlin.chat.constant.ChatError
+import org.tenten.bittakotlin.chat.dto.ChatRoomRequestDto
+import org.tenten.bittakotlin.chat.entity.ChatRoom
+import org.tenten.bittakotlin.chat.entity.ChatRoomProfile
+import org.tenten.bittakotlin.chat.repository.ChatRoomProfileRepository
+import org.tenten.bittakotlin.chat.repository.ChatRoomRepository
+import org.tenten.bittakotlin.media.exception.ChatException
+import org.tenten.bittakotlin.profile.entity.Profile
+import org.tenten.bittakotlin.profile.service.ProfileService
+
+@Service
+class ChatRoomServiceImpl(
+    private val chatRoomRepository: ChatRoomRepository,
+
+    private val chatRoomProfileRepository: ChatRoomProfileRepository,
+
+    private val profileService: ProfileService
+) : ChatRoomService {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(ChatRoomServiceImpl::class.java)
+    }
+
+    override fun getChatRoomByNicknames(nickname1: String, nickname2: String): ChatRoom {
+        return chatRoomProfileRepository.findChatRoomByNicknames(nickname1, nickname2)
+            .orElseThrow { throw NoSuchElementException() }
+    }
+
+    override fun save(requestDto: ChatRoomRequestDto.Create): ChatRoom {
+        val nickname1: String = requestDto.nickname1
+        val nickname2: String = requestDto.nickname2
+        val chatRoom: ChatRoom = chatRoomRepository.save(ChatRoom())
+
+        try {
+            chatRoomProfileRepository.saveAll(listOf(
+                createChatRoomProfile(chatRoom, nickname1),
+                createChatRoomProfile(chatRoom, nickname2)
+            ))
+        } catch (e: NoSuchElementException) {
+            logger.info("Cannot found any member with those nicknames: nickname1=$nickname1, nickname2=$nickname2");
+            throw ChatException(ChatError.CANNOT_FOUND_MEMBER)
+        }
+
+        return chatRoom
+    }
+
+    private fun createChatRoomProfile(chatRoom: ChatRoom, nickname: String): ChatRoomProfile {
+        val profile: Profile = profileService.getByNickname(nickname)
+
+        return ChatRoomProfile(
+            chatRoom = chatRoom,
+            profile = profile
+        )
+    }
+
+    override fun toggleBlocked(requestDto: ChatRoomRequestDto.Block): Boolean {
+        val (requester, target) = requestDto
+        var blocked: Boolean = false
+
+        try {
+            val chatRoom: ChatRoom = getChatRoomByNicknames(requester, target)
+            val requesterProfile = chatRoomProfileRepository.findChatRoomByChatRoomAndNickname(chatRoom, requester);
+            val targetProfile = chatRoomProfileRepository.findChatRoomByChatRoomAndNickname(chatRoom, target)
+
+            requesterProfile.blocked = !requesterProfile.blocked
+            chatRoomProfileRepository.save(requesterProfile)
+
+            chatRoom.activated = requesterProfile.blocked && targetProfile.blocked
+            chatRoomRepository.save(chatRoom)
+
+            blocked = requesterProfile.blocked
+        } catch (e: NoSuchElementException) {
+            logger.error("Cannot found any chat room or member: requester=$requester, target=$target")
+            throw ChatException(ChatError.CANNOT_FOUND_CHATROOM)
+        }
+
+        return blocked
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatService.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatService.kt
@@ -1,0 +1,12 @@
+package org.tenten.bittakotlin.chat.service
+
+import org.tenten.bittakotlin.chat.dto.ChatRequestDto
+import org.tenten.bittakotlin.chat.dto.ChatResponseDto
+
+interface ChatService {
+    fun get(requestDto: ChatRequestDto.Read): List<ChatResponseDto.Read>
+
+    fun save(requestDto: ChatRequestDto.Send): ChatResponseDto.Send
+
+    fun delete(chatId: Long): Long?
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatServiceImpl.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/chat/service/ChatServiceImpl.kt
@@ -1,0 +1,110 @@
+package org.tenten.bittakotlin.chat.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.tenten.bittakotlin.chat.constant.ChatError
+import org.tenten.bittakotlin.chat.dto.ChatRequestDto
+import org.tenten.bittakotlin.chat.dto.ChatResponseDto
+import org.tenten.bittakotlin.chat.dto.ChatRoomRequestDto
+import org.tenten.bittakotlin.chat.entity.Chat
+import org.tenten.bittakotlin.chat.entity.ChatRoom
+import org.tenten.bittakotlin.chat.repository.ChatRepository
+import org.tenten.bittakotlin.media.exception.ChatException
+import org.tenten.bittakotlin.profile.service.ProfileService
+
+@Service
+class ChatServiceImpl(
+    private val chatRepository: ChatRepository,
+
+    private val chatRoomService: ChatRoomService,
+
+    private val profileService: ProfileService
+) : ChatService {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(ChatServiceImpl::class.java)
+    }
+
+    override fun get(requestDto: ChatRequestDto.Read): List<ChatResponseDto.Read> {
+        var result: MutableList<ChatResponseDto.Read> = mutableListOf()
+
+        try {
+            val chatRoom: ChatRoom = chatRoomService.getChatRoomByNicknames(requestDto.sender, requestDto.receiver)
+            val chats: List<Chat> = chatRepository.findAllByChatRoomId(chatRoom.id!!)
+
+            chats.forEach { c -> result.add(
+                ChatResponseDto.Read(
+                    chatId = c.id!!,
+                    sender = c.profile.nickname,
+                    message = c.message,
+                    deleted = c.deleted,
+                    chatAt = c.createdAt!!
+                ))
+            }
+        } catch (e: NoSuchElementException) {
+            logger.info("Cannot load chat list cause chatroom was not found.")
+            throw ChatException(ChatError.CANNOT_FOUND_CHATROOM)
+        }
+
+        return result
+    }
+
+    override fun save(requestDto: ChatRequestDto.Send): ChatResponseDto.Send {
+        var chatRoom: ChatRoom
+
+        try {
+            chatRoom = chatRoomService.getChatRoomByNicknames(requestDto.sender, requestDto.receiver)
+        } catch (e: NoSuchElementException) {
+            logger.info("Creating a new chatroom cause chatroom was not found.")
+            chatRoom = chatRoomService.save(ChatRoomRequestDto.Create(
+                nickname1 = requestDto.sender,
+                nickname2 = requestDto.receiver
+            ))
+        }
+
+        if (!chatRoom.activated) {
+            throw ChatException(ChatError.CANNOT_CHAT_CAUSE_BLOCKED)
+        }
+
+        val chat: Chat = chatRepository.save(
+            Chat(
+                profile = profileService.getByNickname(requestDto.sender),
+                message = requestDto.message,
+                chatRoom = chatRoom,
+                createdAt = null,
+                updatedAt = null
+            )
+        )
+
+        return ChatResponseDto.Send(
+            chatRoomId = chatRoom.id!!,
+            activated = chatRoom.activated,
+            ChatResponseDto.Detail(
+                chatId = chat.id!!,
+                sender = chat.profile.nickname,
+                message = chat.message,
+                chatAt = chat.createdAt!!
+            )
+        )
+    }
+
+    override fun delete(chatId: Long): Long {
+        var chat: Chat = getChatById(chatId)
+
+        if (chat.deleted) {
+            throw ChatException(ChatError.ALREADY_DELETED_CHAT)
+        }
+
+        chat.message = "삭제된 메시지 입니다."
+        chat.deleted = true
+
+        chatRepository.save(chat)
+
+        return chat.chatRoom.id!!
+    }
+
+    private fun getChatById(chatId: Long): Chat {
+        return chatRepository.findById(chatId)
+            .orElseThrow { ChatException(ChatError.CANNOT_FOUND_CHAT) }
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/global/config/WebSocketConfig.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/global/config/WebSocketConfig.kt
@@ -1,0 +1,22 @@
+package org.tenten.bittakotlin.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/api/v1/chat")
+            .setAllowedOriginPatterns("*")
+            .withSockJS()
+    }
+
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.setApplicationDestinationPrefixes("/api/v1")
+            .enableSimpleBroker("/room")
+    }
+}

--- a/src/main/kotlin/org/tenten/bittakotlin/profile/repository/ProfileRepository.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/profile/repository/ProfileRepository.kt
@@ -1,9 +1,15 @@
 package org.tenten.bittakotlin.profile.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.tenten.bittakotlin.profile.entity.Profile
+import java.util.Optional
 
 
 interface ProfileRepository : JpaRepository<Profile, Long> {
     fun findByMemberId(memberId: Long): Profile?
+
+    @Query("SELECT p FROM Profile p WHERE p.nickname = :nickname")
+    fun findByNickname(@Param("nickname") nickname: String): Optional<Profile>
 }

--- a/src/main/kotlin/org/tenten/bittakotlin/profile/service/ProfileService.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/profile/service/ProfileService.kt
@@ -2,10 +2,13 @@ package org.tenten.bittakotlin.profile.service
 
 import org.tenten.bittakotlin.member.entity.Member
 import org.tenten.bittakotlin.profile.dto.ProfileDTO
+import org.tenten.bittakotlin.profile.entity.Profile
 
 interface ProfileService {
     fun createProfile(ProfileDTO: ProfileDTO): ProfileDTO
     fun getProfile(memberId: Long): ProfileDTO
     fun updateProfile(memberId: Long, profileDTO: ProfileDTO): ProfileDTO
     fun createDefaultProfile(member: Member): ProfileDTO
+
+    fun getByNickname(nickname: String): Profile
 }

--- a/src/main/kotlin/org/tenten/bittakotlin/profile/service/ProfileServiceImpl.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/profile/service/ProfileServiceImpl.kt
@@ -101,6 +101,11 @@ class ProfileServiceImpl(
         )
     }
 
+    override fun getByNickname(nickname: String): Profile {
+        return profileRepository.findByNickname(nickname)
+            .orElseThrow { NoSuchElementException() }
+    }
+
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(ProfileServiceImpl::class.java)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
See: prgrms-be-devcourse/NBB1_2_3_Team10#9


## ☑️ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정


## 📝 작업 내용
웹소켓, 채팅 관련 컴포넌트를 자바에서 코틀린으로 마이그레이션하고,
잘못된 기능들을 수정하고 추가 기능을 구현하며 리팩토링을 수행했습니다.
대략적인 사항은 아래와 같습니다.

- 회원 간에 채팅방을 경유하여 의사소통이 가능합니다.
- 채팅 조회, 삭제, 전송 그리고 회원 차단 기능을 구현했습니다.
- 채팅 CORS 설정은 "*'로 GET/POST/PUT/DELETE 전체 허용해 두었습니다.

## ✅ 피드백 반영사항
피드백 사항은 따로 없습니다.

## 💬 리뷰 요구사항
채팅 테스트는 프론트가 어느정도 구현되고 실시할 예정입니다.

